### PR TITLE
Update copyrights

### DIFF
--- a/midonet/__init__.py
+++ b/midonet/__init__.py
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2012 Midokura Japan K.K.
 # Copyright (C) 2013 Midokura PTE LTD
+# Copyright (C) 2014 Midokura SARL.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/midonet/neutron/__init__.py
+++ b/midonet/neutron/__init__.py
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2012 Midokura Japan K.K.
 # Copyright (C) 2013 Midokura PTE LTD
+# Copyright (C) 2014 Midokura SARL.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/midonet/neutron/agent/__init__.py
+++ b/midonet/neutron/agent/__init__.py
@@ -1,6 +1,7 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 
 # Copyright (C) 2013 Midokura PTE LTD
+# Copyright (C) 2014 Midokura SARL.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/midonet/neutron/agent/midonet_driver.py
+++ b/midonet/neutron/agent/midonet_driver.py
@@ -1,6 +1,7 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 
 # Copyright (C) 2013 Midokura PTE LTD
+# Copyright (C) 2014 Midokura SARL.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/midonet/neutron/common/__init__.py
+++ b/midonet/neutron/common/__init__.py
@@ -1,6 +1,7 @@
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
 
 # Copyright (C) 2013 Midokura PTE LTD
+# Copyright (C) 2014 Midokura SARL.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/midonet/neutron/common/config.py
+++ b/midonet/neutron/common/config.py
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2012 Midokura Japan K.K.
 # Copyright (C) 2013 Midokura PTE LTD
+# Copyright (C) 2014 Midokura SARL.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/midonet/neutron/plugin.py
+++ b/midonet/neutron/plugin.py
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2012 Midokura Japan K.K.
 # Copyright (C) 2013 Midokura PTE LTD
+# Copyright (C) 2014 Midokura SARL.
 # All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may


### PR DESCRIPTION
This patch updates the copyright notifications in the headers of files.
The following patches added by Midokura should use the same copyright
statement as follow:

  Copyright (C) 2014 Midokura SARL.

Signed-off-by: Taku Fukushima tfukushima@midokura.com
